### PR TITLE
themes for QLColorCode based on Solarized

### DIFF
--- a/solarized-dark.style
+++ b/solarized-dark.style
@@ -1,0 +1,20 @@
+# solarized-dark.style
+# This File is part of highlight, a universal source code converter.
+# See README in the highlight directory for documentation.
+
+$DEFAULTCOLOUR=#839496
+$BGCOLOUR=#002b36
+$FONTSIZE=10
+$KW-GROUP(kwa)=#cb4b16
+$KW-GROUP(kwb)=#859900
+$KW-GROUP(kwc)=#cb4b16
+$KW-GROUP(kwd)=#93a1a1
+$NUMBER=#dc322f
+$ESCAPECHAR=#6c71c4
+$STRING=#dc322f
+$STRING-DIRECTIVE=#dc322f
+$COMMENT=#586e75
+$DIRECTIVE=#6c71c4
+$LINE=#268bd2
+$SYMBOL=#93a1a1
+$MARK-LINE=#073642

--- a/solarized-light.style
+++ b/solarized-light.style
@@ -1,0 +1,20 @@
+# solarized-light.style
+# This File is part of highlight, a universal source code converter.
+# See README in the highlight directory for documentation.
+
+$DEFAULTCOLOUR=#657b83
+$BGCOLOUR=#fdf6e3
+$FONTSIZE=10
+$KW-GROUP(kwa)=#cb4b16
+$KW-GROUP(kwb)=#859900
+$KW-GROUP(kwc)=#cb4b16
+$KW-GROUP(kwd)=#586e75
+$NUMBER=#dc322f
+$ESCAPECHAR=#6c71c4
+$STRING=#dc322f
+$STRING-DIRECTIVE=#dc322f
+$COMMENT=#93a1a1
+$DIRECTIVE=#6c71c4
+$LINE=#268bd2
+$SYMBOL=#586e75
+$MARK-LINE=#073642


### PR DESCRIPTION
Solarized (http://ethanschoonover.com/solarized) is a low-contrast color palette designed for high readability against either a dark or a light background.

There's a lot more information about Solarized on the page linked above.  I've also submitted these themes to the Highlight maintainer, but I don't know how responsive he'll be, so I'm submitting them to you as well.

I also don't have a good handle on how to add those files to the XCode project, unfortunately.

-Steve
